### PR TITLE
update bundler and launcher for macos arm64

### DIFF
--- a/scripts/bundler.sh
+++ b/scripts/bundler.sh
@@ -78,7 +78,7 @@ main() {
       download_jre_and_electron
 
       RELEASE="$RELEASE_NAME.zip"
-      make_macos_bundle
+      make_macosarm_bundle
       move_release_to_output_dir
       ;;
     windows-x86)
@@ -173,6 +173,15 @@ make_macos_bundle() {
   cp "scripts/resources/Tachidesk Browser Launcher.command" "$RELEASE_NAME/"
   cp "scripts/resources/Tachidesk Debug Launcher.command" "$RELEASE_NAME/"
   cp "scripts/resources/Tachidesk Electron Launcher.command" "$RELEASE_NAME/"
+
+  zip -9 -r "$RELEASE" "$RELEASE_NAME/"
+}
+
+make_macosarm_bundle() {
+  cp "$JAR" "$RELEASE_NAME/Tachidesk-Server.jar"
+  cp "scripts/resources/Tachidesk Browser Launcher Arm64.command" "$RELEASE_NAME/"
+  cp "scripts/resources/Tachidesk Debug Launcher Arm64.command" "$RELEASE_NAME/"
+  cp "scripts/resources/Tachidesk Electron Launcher Arm64.command" "$RELEASE_NAME/"
 
   zip -9 -r "$RELEASE" "$RELEASE_NAME/"
 }

--- a/scripts/resources/Tachidesk Browser Launcher Arm64.command
+++ b/scripts/resources/Tachidesk Browser Launcher Arm64.command
@@ -1,0 +1,3 @@
+cd "`dirname "$0"`"
+
+./jre/zulu-8.jre/Contents/Home/bin/java -jar Tachidesk-Server.jar

--- a/scripts/resources/Tachidesk Debug Launcher Arm64.command
+++ b/scripts/resources/Tachidesk Debug Launcher Arm64.command
@@ -1,0 +1,3 @@
+cd "`dirname "$0"`"
+
+./jre/zulu-8.jre/Contents/Home/bin/java -Dsuwayomi.tachidesk.config.server.debugLogsEnabled=true -jar  Tachidesk-Server.jar

--- a/scripts/resources/Tachidesk Electron Launcher Arm64.command
+++ b/scripts/resources/Tachidesk Electron Launcher Arm64.command
@@ -1,0 +1,3 @@
+cd "`dirname "$0"`"
+
+./jre/zulu-8.jre/Contents/Home/bin/java "-Dsuwayomi.tachidesk.config.server.webUIInterface=electron" "-Dsuwayomi.tachidesk.config.server.electronPath=electron/Electron.app/Contents/MacOS/Electron" -jar Tachidesk-Server.jar


### PR DESCRIPTION
Fix cant find java error because of wrong path.
As the default  zulu arm jre8 have bit different folder structure (jre/zulu-jre.jre/Contents/...)

The macos arm64 need a seperate launcher as macos x64 uses temurin